### PR TITLE
fix(theme): preserve user preference

### DIFF
--- a/rosewt-astro/src/components/ThemeToggle.jsx
+++ b/rosewt-astro/src/components/ThemeToggle.jsx
@@ -1,13 +1,16 @@
 import { useEffect, useState } from "react";
 
 export default function ThemeToggle() {
-  const [dark, setDark] = useState(
-    typeof document !== 'undefined' &&
-    (localStorage.getItem('theme') === 'dark' ||
-     (!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches))
-  );
+  const [dark, setDark] = useState(null);
 
   useEffect(() => {
+    const savedTheme = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    setDark(savedTheme === 'dark' || (!savedTheme && prefersDark));
+  }, []);
+
+  useEffect(() => {
+    if (dark === null) return;
     document.documentElement.classList.toggle('dark', dark);
     localStorage.setItem('theme', dark ? 'dark' : 'light');
   }, [dark]);
@@ -15,7 +18,7 @@ export default function ThemeToggle() {
   return (
     <button
       aria-label="Alternar modo"
-      aria-pressed={dark}
+      aria-pressed={dark ?? false}
       onClick={() => setDark(!dark)}
       className="inline-flex items-center rounded-xl border border-slate-200 dark:border-slate-800 px-3 py-1.5 text-sm hover:bg-slate-50 dark:hover:bg-slate-800"
     >🌓</button>


### PR DESCRIPTION
## Summary
- initialize theme from `localStorage` after mount
- apply theme only when preference is resolved and update accessibility state

## Testing
- `npm test` (fails: Missing script)
- `npm run check` (fails: requires @astrojs/check and typescript)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7eeca42fc8322bc67646c2bef6866