### PR TITLE
DocAsCode and Agents Orchestation

### DIFF
--- a/.codex
+++ b/.codex
@@ -7,3 +7,5 @@ Default evidence workflow:
 - Use `evidence/claims.md` for claim traceability.
 - Do not inspect `.cv-vault/` unless the user explicitly asks.
 - Treat `CLAUDE.md` as technical context only. If there is a conflict, `agents.md` wins.
+- For durable rationale, check `docs/adr/`.
+- For multi-step implementation work, check `docs/plans/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Canonical repo policy, editorial rules, and evidence handling live in `agents.md
 - `agents.md` wins if there is any conflict.
 - Use `cv/master.md` for narrative content and `evidence/claims.md` for factual traceability.
 - Do not inspect `.cv-vault/` unless the user explicitly asks for private evidence.
+- Use `docs/adr/` for accepted durable decisions and `docs/plans/` for active multi-step work.
 
 ## Project Structure
 

--- a/agents.md
+++ b/agents.md
@@ -10,6 +10,19 @@ The goal is to present a consistent narrative as an early-career **Applied ML En
 This file is the canonical policy for agent behavior in this repo.
 If `CLAUDE.md` or `.codex` differ from this file, `agents.md` wins.
 
+## Docs As Code
+
+Process and architecture documentation lives under `docs/`.
+
+- `docs/adr/`: durable decisions that should not be re-decided each session
+- `docs/plans/`: decision-complete initiative plans for multi-step work
+- `docs/standards/`: working conventions and data contracts
+
+Workflow rules:
+- Before substantial multi-step work, check for an active plan in `docs/plans/` or create one.
+- If a change introduces a durable process or architecture decision, add or update an ADR.
+- If a reusable convention changes, update the relevant standard instead of scattering the rule across prompts and comments.
+
 ## Source of Truth
 
 | Artifact | Source |
@@ -89,6 +102,12 @@ When updating factual content:
 4. Propagate to `cv/main.tex`
 5. Propagate to website (`constants.ts`, MDX files)
 6. Verify cross-consistency
+
+When updating process or workflow:
+1. Update or add the relevant ADR in `docs/adr/` if the decision is durable
+2. Update the relevant standard in `docs/standards/` if conventions changed
+3. Update `agents.md` if agent-facing behavior changed
+4. Update or create a plan in `docs/plans/` if the work remains active
 
 ## Project Inclusion Criteria
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# Docs as Code
+
+This repository uses docs as code for durable decisions, active implementation plans, and working conventions that agents should follow.
+
+## Structure
+
+- `docs/adr/`: accepted architectural and process decisions that should not be re-litigated every session
+- `docs/plans/`: decision-complete initiative plans for multi-step work
+- `docs/standards/`: living conventions for evidence, plans, and authoring rules
+
+## Usage Rules
+
+- Update or add an ADR when a durable decision changes repo policy, evidence modeling, or the agent workflow.
+- Create or update a plan before substantial multi-step work that spans multiple files or decisions.
+- Update standards when a convention changes but does not require a new ADR.
+- Keep `agents.md` aligned with accepted ADRs. If there is temporary drift, `agents.md` remains the execution-time policy until reconciled.
+
+## Precedence
+
+1. `agents.md` for active execution behavior in this repo
+2. accepted ADRs for durable rationale and architectural decisions
+3. standards for conventions and data contracts
+4. plans for initiative-specific execution details

--- a/docs/adr/ADR-0001-canonical-agent-policy.md
+++ b/docs/adr/ADR-0001-canonical-agent-policy.md
@@ -1,0 +1,28 @@
+# ADR-0001: Canonical Agent Policy
+
+- Status: Accepted
+- Date: 2026-04-08
+
+## Context
+
+The repo already had agent-facing documents with overlapping responsibilities: `agents.md`, `CLAUDE.md`, and `.codex`.
+Without a canonical rule, process drift and contradictory instructions become likely.
+
+## Decision
+
+- `agents.md` is the canonical execution policy for this repository.
+- `CLAUDE.md` provides technical repo orientation only.
+- `.codex` is a short pointer document, not a full policy document.
+- Durable rationale belongs in `docs/adr/`.
+- Initiative-specific execution plans belong in `docs/plans/`.
+
+## Consequences
+
+- Process changes must be reflected in `agents.md`.
+- `CLAUDE.md` and `.codex` should stay intentionally short.
+- Agents have a clear first stop for behavior and a separate home for rationale.
+
+## Alternatives Rejected
+
+- Keeping all agent documents fully synchronized with complete duplicated policy.
+- Making `CLAUDE.md` the canonical policy file.

--- a/docs/adr/ADR-0002-evidence-layer-separation.md
+++ b/docs/adr/ADR-0002-evidence-layer-separation.md
@@ -1,0 +1,28 @@
+# ADR-0002: Evidence Layer Separation
+
+- Status: Accepted
+- Date: 2026-04-08
+
+## Context
+
+The repo needs factual traceability for CV and website claims, but private documents and heavy artifacts should not be scanned by default or committed to Git.
+Public claims, narrative content, and private evidence each have different privacy and maintenance requirements.
+
+## Decision
+
+- `cv/master.md` is the narrative source of truth.
+- `evidence/claims.md` is the factual traceability registry for public and internal claims.
+- `.cv-vault/INDEX.md` indexes private evidence stored locally in `.cv-vault/`.
+- `.cv-vault/` remains opt-in, ignored by Git, and should not be inspected unless the user explicitly requests it or the task requires it.
+- Public artifacts stay in `evidence/claims.md`; private backups or snapshots may live in `.cv-vault/` only when justified.
+
+## Consequences
+
+- Agents can answer most factual questions from `evidence/claims.md` without opening private files.
+- Sensitive work claims can remain traceable while marked non-public.
+- The evidence system stays cheap in tokens and safe by default.
+
+## Alternatives Rejected
+
+- Storing all evidence directly in Git.
+- Using only one registry for both public links and private files without separation.

--- a/docs/adr/ADR-0003-agentic-development-workflow.md
+++ b/docs/adr/ADR-0003-agentic-development-workflow.md
@@ -1,0 +1,27 @@
+# ADR-0003: Agentic Development Workflow
+
+- Status: Accepted
+- Date: 2026-04-08
+
+## Context
+
+Multi-step work was being planned ad hoc in chat. That makes handoff difficult and causes repeated re-decisions on scope, file ownership, and acceptance criteria.
+
+## Decision
+
+- Use `docs/plans/` for decision-complete initiative plans.
+- Every plan must declare a status from: `proposed`, `active`, `blocked`, `done`, or `superseded`.
+- Plans must state the exact artifacts or subsystems they affect, the decisions already taken, and acceptance criteria.
+- If a change introduces a durable process or architecture decision, create or update an ADR before considering the initiative complete.
+- Standards documents define the reusable conventions that plans should reference rather than restate.
+
+## Consequences
+
+- Agents can pick up substantial work without rebuilding the same context from scratch.
+- Temporary plans do not replace durable ADRs.
+- Workflows become easier to review, resume, or supersede.
+
+## Alternatives Rejected
+
+- Tracking all plans only in transient chat history.
+- Using ADRs for temporary initiative planning.

--- a/docs/plans/2026-04-08-evidence-and-agentic-foundation.md
+++ b/docs/plans/2026-04-08-evidence-and-agentic-foundation.md
@@ -1,0 +1,74 @@
+# Plan: Evidence And Agentic Foundation
+
+- Status: proposed
+- Date: 2026-04-08
+
+## Summary
+
+Harden the evidence model, align the narrative with what is actually supportable today, and add a light agentic workflow so future work is resumable and automation-friendly.
+
+## Decisions Already Taken
+
+- `agents.md` remains the canonical execution policy.
+- `cv/master.md` is narrative truth; `evidence/claims.md` is factual traceability; `.cv-vault/INDEX.md` indexes private evidence.
+- `Ask-Papa` is work-sensitive and should remain internal-only in the claims layer.
+- `Imitator` may be backed by a private Springer publisher record.
+- UPC should be tracked with a reduced claim until stronger evidence exists.
+- `Winter Camp AI 2025` stays out of the claims registry until proof is recovered.
+
+## Implementation Slices
+
+### 1. Narrative Alignment
+
+- Target artifacts: `cv/master.md`, `evidence/claims.md`, website-derived content as needed
+- Required changes:
+  - remove or reduce unsupported narrative claims
+  - keep naming consistent across CV and web surfaces
+  - ensure sensitive work stays internal-only in traceability
+- Acceptance criteria:
+  - no claim in public-facing surfaces contradicts the registry
+  - sensitive work claims are clearly marked non-public
+
+### 2. Claims Registry V2
+
+- Target artifacts: `evidence/claims.md`, `docs/standards/claims-registry.md`
+- Required changes:
+  - consider adding optional fields like `status` and `sensitivity`
+  - split large bundled claims into smaller verifiable units where useful
+  - keep support references minimal and real
+- Acceptance criteria:
+  - each important public claim is independently traceable
+  - no `vault_doc` points to a missing index entry
+
+### 3. Evidence Validator
+
+- Target artifacts: `rosewt-astro/scripts/verify-evidence.mjs`, `rosewt-astro/package.json`
+- Required changes:
+  - add a script that validates `claim_id` uniqueness
+  - validate each `vault_doc` against `.cv-vault/INDEX.md`
+  - validate each indexed file path exists on disk
+- Acceptance criteria:
+  - a single command reports broken references and duplicate IDs
+  - validation runs without mutating tracked files
+
+### 4. Public Evidence Subset
+
+- Target artifacts: `evidence/public-evidence.md`
+- Required changes:
+  - curate only safe, public-facing proofs such as papers, awards, selected certs, and repos
+  - exclude private or work-sensitive evidence
+- Acceptance criteria:
+  - the subset can feed a future web section without exposing private material
+  - every public item maps back to a real claim
+
+## Risks and Notes
+
+- Narrative drift can reappear if `cv/master.md` changes without registry updates.
+- Sensitive work claims need deliberate review before becoming public.
+- Private evidence should remain opt-in even if automation is added.
+
+## Related ADRs
+
+- `ADR-0001`
+- `ADR-0002`
+- `ADR-0003`

--- a/docs/plans/TEMPLATE.md
+++ b/docs/plans/TEMPLATE.md
@@ -1,0 +1,35 @@
+# Plan: <Title>
+
+- Status: proposed
+- Date: YYYY-MM-DD
+
+## Summary
+
+Describe the user outcome and why the work exists.
+
+## Decisions Already Taken
+
+- Decision 1
+- Decision 2
+
+## Implementation Slices
+
+### 1. <Slice Name>
+
+- Target artifacts:
+- Required changes:
+- Acceptance criteria:
+
+### 2. <Slice Name>
+
+- Target artifacts:
+- Required changes:
+- Acceptance criteria:
+
+## Risks and Notes
+
+- Risk or dependency
+
+## Related ADRs
+
+- `ADR-XXXX`

--- a/docs/standards/claims-registry.md
+++ b/docs/standards/claims-registry.md
@@ -1,0 +1,38 @@
+# Claims Registry Standard
+
+## Purpose
+
+`evidence/claims.md` is the traceability registry for claims that may appear in the CV, website, or agent responses.
+
+## Required Fields
+
+Each claim block must contain:
+
+- `claim_id`: stable short identifier
+- `surface`: `cv`, `web`, or `both`
+- `publicable`: `yes` or `no`
+- `claim`: factual statement
+- `supports`: one or more support references
+
+## Support Types
+
+Allowed support prefixes:
+
+- `repo`
+- `public_url`
+- `paper`
+- `vault_doc`
+- `screenshot`
+
+`vault_doc` may point to private PDFs, publisher records, or private email exports indexed in `.cv-vault/INDEX.md`.
+
+## Writing Rules
+
+- Keep claims factual and compact.
+- Use `publicable: no` for internal or work-sensitive claims.
+- Avoid large bundled claims when smaller verifiable claims are possible.
+- If a claim cannot be supported today, either reduce it, mark it non-public, or remove it from the registry.
+
+## Future Extensions
+
+If the repo later adds fields like `status` or `sensitivity`, update this standard before relying on them in automation.

--- a/docs/standards/evidence-vault.md
+++ b/docs/standards/evidence-vault.md
@@ -1,0 +1,35 @@
+# Evidence Vault Standard
+
+## Purpose
+
+`.cv-vault/` stores private or heavy evidence that should remain local and opt-in.
+
+## Directory Layout
+
+- `.cv-vault/certificaciones/`
+- `.cv-vault/constancias-laborales/`
+- `.cv-vault/educacion/`
+- `.cv-vault/otros-soportes/`
+
+## Naming Convention
+
+Use:
+
+`YYYY-MM-DD__issuer__type__slug.ext`
+
+Examples:
+
+- `2025-09-16__datacamp__certification__ai-engineer-for-data-scientists-associate.pdf`
+- `2026-04-01__cip__employment__practices-renewal.pdf`
+
+## Index Rules
+
+- Every file used for traceability must have a `doc_id` entry in `.cv-vault/INDEX.md`.
+- `.cv-vault/INDEX.md` should only contain real files, not placeholders.
+- The `claim_id` in the index must reference a real claim or be left intentionally empty only for unclaimed archival material.
+
+## Privacy Rules
+
+- Do not inspect `.cv-vault/` by default.
+- Do not quote private evidence into public artifacts unless the user explicitly requests it.
+- Prefer public links in `evidence/claims.md` when they are sufficient.

--- a/docs/standards/plan-lifecycle.md
+++ b/docs/standards/plan-lifecycle.md
@@ -1,0 +1,39 @@
+# Plan Lifecycle Standard
+
+## When to Create a Plan
+
+Create or update a plan in `docs/plans/` when work:
+
+- spans multiple files or subsystems
+- needs durable decisions to be carried across sessions
+- is likely to be resumed, delegated, or reviewed later
+
+## Plan Statuses
+
+- `proposed`: scoped but not yet being executed
+- `active`: currently driving implementation
+- `blocked`: cannot proceed until an external dependency or decision is resolved
+- `done`: implemented and no longer the active source of work
+- `superseded`: replaced by another plan
+
+## File Naming
+
+Use:
+
+`YYYY-MM-DD-short-slug.md`
+
+## Decision-Complete Requirement
+
+A plan should be decision-complete before heavy implementation starts.
+That means the implementer should not need to guess:
+
+- what to change
+- where to change it
+- what constraints apply
+- how success will be checked
+
+## Maintenance Rules
+
+- Update the status when work meaningfully changes state.
+- Link relevant ADRs instead of repeating stable rationale.
+- Supersede old plans instead of editing history until it becomes ambiguous.

--- a/evidence/claims.md
+++ b/evidence/claims.md
@@ -18,7 +18,7 @@ Support references use one of these prefixes:
 - `repo`: public source repository
 - `public_url`: public page, profile, demo, release, or PDF
 - `paper`: paper page, preprint, or publication record
-- `vault_doc`: local private evidence indexed in `.cv-vault/INDEX.md`
+- `vault_doc`: local private evidence indexed in `.cv-vault/INDEX.md`, including private emails or publisher records
 - `screenshot`: local snapshot indexed in `.cv-vault/INDEX.md`
 
 ## Experience
@@ -43,10 +43,9 @@ Support references use one of these prefixes:
 
 ### sys-ask-papa-001
 - `surface`: `both`
-- `publicable`: `yes`
-- `claim`: Built a document intelligence and RAG pipeline for agricultural research corpora with ingestion, parsing, chunking, embeddings, and vector indexing.
+- `publicable`: `no`
+- `claim`: Internal collaboration on a document intelligence and RAG workflow within current work at CIP; keep as internal context, not as a public claim to verify externally.
 - `supports`:
-  - `vault_doc`: `ask_papa_internal_summary`
   - `public_url`: `https://rosewt.dev/`
 
 ### sys-arbitria-001
@@ -81,17 +80,16 @@ Support references use one of these prefixes:
 - `claim`: Co-authored the multimodal sign language translation system "Imitator", accepted for Springer CCIS 2026 and pending publication.
 - `supports`:
   - `repo`: `https://github.com/nakato156/Multimodal-Sign-Language-Model`
-  - `vault_doc`: `imitator_acceptance_notice`
+  - `vault_doc`: `imitator_springer_publication_record`
 
 ## Education
 
 ### edu-upc-001
 - `surface`: `both`
 - `publicable`: `yes`
-- `claim`: B.Sc. Computer Science student at UPC, expected graduation in 2026-2, top 10% of class.
+- `claim`: B.Sc. Computer Science student at UPC, expected graduation in 2026-2.
 - `supports`:
-  - `vault_doc`: `upc_enrollment_2026`
-  - `vault_doc`: `upc_rank_record_2026`
+  - `public_url`: `https://www.linkedin.com/in/r0sewt/`
 
 ## Certifications
 
@@ -122,10 +120,3 @@ Support references use one of these prefixes:
 - `claim`: Python for Everybody by the University of Michigan.
 - `supports`:
   - `vault_doc`: `python_for_everybody_certificate`
-
-### cert-pucp-wcai-001
-- `surface`: `both`
-- `publicable`: `yes`
-- `claim`: Winter Camp AI 2025 by PUCP.
-- `supports`:
-  - `vault_doc`: `pucp_winter_camp_ai_2025`


### PR DESCRIPTION
This pull request introduces a comprehensive "docs as code" foundation for agentic and evidence-driven workflows in the repository. It establishes clear canonical policy and evidence handling rules, adds architectural decision records (ADRs), and provides standards and templates for claims, plans, and private evidence. The changes clarify file roles, update agent guidance, and ensure all agent-facing behavior, traceability, and workflow conventions are durable, reviewable, and automation-friendly.

**Policy and Governance**

* [`agents.md`](diffhunk://#diff-b951327c37d8a1ed4d5ed18908681f6aca718ecdfe174aa39cf2237547f92fe7L8-R50): Now explicitly the canonical policy file for agent behavior, detailing evidence handling, update protocols, and the precedence of policy documents. Adds rules for updating content, evidence, and process, and clarifies the relationship between public/private content and claims. [[1]](diffhunk://#diff-b951327c37d8a1ed4d5ed18908681f6aca718ecdfe174aa39cf2237547f92fe7L8-R50) [[2]](diffhunk://#diff-b951327c37d8a1ed4d5ed18908681f6aca718ecdfe174aa39cf2237547f92fe7L38-L39) [[3]](diffhunk://#diff-b951327c37d8a1ed4d5ed18908681f6aca718ecdfe174aa39cf2237547f92fe7L61-L89)
* `.codex`, `CLAUDE.md`: Updated to point to `agents.md` as the source of truth, clarify their limited roles, and provide consistent guidance for technical orientation and editorial governance. [[1]](diffhunk://#diff-a1d1128ffe5a2849afb3ac4cad6413b6d75453babc7cac579b95c66a565fe4ccR1-R11) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L3-R11) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L55-R66)

**Evidence and Traceability Standards**

* [`docs/adr/ADR-0002-evidence-layer-separation.md`](diffhunk://#diff-17fec01a810bd1e11cbd6543eedf7ebadd157f9c3d9277cbb439ca300ae049f3R1-R28): Establishes the separation of narrative, public claims, and private evidence, with `.cv-vault/` as opt-in and not scanned by default.
* `docs/standards/claims-registry.md`, `docs/standards/evidence-vault.md`: Define the required fields, structure, and privacy rules for claims and private evidence, ensuring traceability and safe handling of sensitive material. [[1]](diffhunk://#diff-3f777431fa6d25f795db1217d6b4e8a063fe67d07d527d1dbadb7cbfe64f431cR1-R38) [[2]](diffhunk://#diff-5f8b7a9c99059bf34a79f213fa4b65f8f88a4b7fa35dd210895691dd0647876bR1-R35)

**Agentic Workflow and Planning**

* `docs/adr/ADR-0003-agentic-development-workflow.md`, `docs/standards/plan-lifecycle.md`, `docs/plans/TEMPLATE.md`: Introduce a plan lifecycle, template, and workflow for multi-step or cross-session work, requiring decision-complete plans and clear status tracking. [[1]](diffhunk://#diff-c6ae174eceb8d616d902c2e1c2bca607411ed93102c8178b992be118942b3869R1-R27) [[2]](diffhunk://#diff-c0080acc5cf239fb415bb0fdd3d91a9487194b634b83b60dc59d1e28d0587001R1-R39) [[3]](diffhunk://#diff-f3141df8f03b556b9a548679ec2e0ecf9213b6e32dcc134303d3739f168d8469R1-R35)
* [`docs/README.md`](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R1-R23): Documents the "docs as code" approach, file structure, and rules for updating ADRs, plans, and standards, with explicit precedence order.

**Implementation and Rationale**

* [`docs/adr/ADR-0001-canonical-agent-policy.md`](diffhunk://#diff-fbd1aa0d541f32abe9edb155b237f99f5cd2435aa2e306288881f6ba57248d93R1-R28): Records the decision that `agents.md` is the canonical execution policy, with supporting rationale and consequences.
* [`docs/plans/2026-04-08-evidence-and-agentic-foundation.md`](diffhunk://#diff-6e19c98fe641fc884e7662e29505a46f0d95c6a912e175a1841d4930fe7536d7R1-R74): Proposes a concrete implementation plan for aligning narrative, claims, and evidence, including validator tooling and public/private separation.

These changes collectively establish a robust, reviewable foundation for agentic work, evidence traceability, and process governance in the repository.

## Summary by Sourcery

Establish a docs-as-code foundation that formalizes canonical agent policy, evidence handling, and agentic workflows for this repository.

New Features:
- Introduce a claims registry for factual traceability across CV, website, and agent responses.
- Add standards and templates for plans, claims, and private evidence management.
- Document an agentic development workflow with decision-complete plans and clear status tracking.

Enhancements:
- Clarify `agents.md` as the single canonical execution policy and narrow `CLAUDE.md` and `.codex` to pointer/orientation roles.
- Normalize frontmatter parsing in the CV generation script to handle different newline styles.
- Add governance rules for evolving narrative content, process, and workflow via ADRs, standards, and plans.

Documentation:
- Add ADRs defining canonical agent policy, evidence layer separation, and an agentic development workflow.
- Document the docs-as-code structure, precedence order between agents, ADRs, standards, and plans, and when to create each artifact.
- Add a reusable plan template and lifecycle standard for multi-step or cross-session work.
- Define standards for the claims registry and evidence vault, including structure, naming, and privacy rules.
- Create an evidence claims registry file capturing key experience, systems, research, education, and certification claims with support references.