### PR TITLE
feat(deck): hero CV CTA, Approach moved late, email copies the address

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -52,3 +52,5 @@
 # - linear.api-key
 # - github.org
 # - github.repo
+
+sync.remote: "git+ssh://git@github.com/R0SEWT/myPage.git"

--- a/site/src/components/deck/screens/Approach.astro
+++ b/site/src/components/deck/screens/Approach.astro
@@ -3,7 +3,8 @@ import { SCREENS, approach } from '../../../data/deck';
 import T from '../T.astro';
 import SecHead from '../SecHead.astro';
 
-const s = SCREENS[1];
+const i = 5;
+const s = SCREENS[i];
 ---
 <section
   class="screen screen--sheet"
@@ -13,7 +14,7 @@ const s = SCREENS[1];
   hidden
 >
   <div class="sheet">
-    <SecHead label={s.label} index={1} />
+    <SecHead label={s.label} index={i} />
     <T t={approach.lede} as="p" class="sheet-lede" />
 
     <div class="sheet-notes">

--- a/site/src/components/deck/screens/Career.astro
+++ b/site/src/components/deck/screens/Career.astro
@@ -3,7 +3,8 @@ import { SCREENS, career } from '../../../data/deck';
 import T from '../T.astro';
 import SecHead from '../SecHead.astro';
 
-const s = SCREENS[5];
+const i = 4;
+const s = SCREENS[i];
 ---
 <section
   class="screen screen--career"
@@ -12,7 +13,7 @@ const s = SCREENS[5];
   data-en={s.label.en}
   hidden
 >
-  <SecHead label={s.label} index={5} />
+  <SecHead label={s.label} index={i} />
 
   {career.map((row) => (
     <div class="lin-row">

--- a/site/src/components/deck/screens/Contact.astro
+++ b/site/src/components/deck/screens/Contact.astro
@@ -1,5 +1,5 @@
 ---
-import { SCREENS, contact, links } from '../../../data/deck';
+import { SCREENS, chrome, contact, links } from '../../../data/deck';
 import T from '../T.astro';
 
 const s = SCREENS[6];
@@ -18,7 +18,10 @@ const s = SCREENS[6];
 
   <T t={contact.title} as="h2" class="ct-title" />
 
-  <a class="ct-mail" href={`mailto:${links.email}`}>{links.email}</a>
+  <span class="copy-wrap">
+    <a class="ct-mail" href={`mailto:${links.email}`} data-copy={links.email}>{links.email}</a>
+    <span class="copy-live" role="status"><T t={chrome.copied} class="copy-flag" /></span>
+  </span>
 
   <T t={contact.note} as="p" class="ct-note" />
 

--- a/site/src/components/deck/screens/Home.astro
+++ b/site/src/components/deck/screens/Home.astro
@@ -22,6 +22,29 @@ const s = SCREENS[0];
       <div><b>{home.name}</b></div>
       <div>{home.role}</div>
       <div>{home.org}</div>
+
+      {home.cv.map((c) => (
+        <a class="cv-dl" data-l={c.lang} href={c.href} download={c.file}>
+          <span class="cv-dl-row">
+            <span class="cv-dl-label">{c.label}</span>
+            <svg
+              class="cv-dl-arrow"
+              width="9"
+              height="9"
+              viewBox="0 0 12 12"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.3"
+              aria-hidden="true"
+            >
+              <line x1="6" y1="1" x2="6" y2="10" />
+              <polyline points="2.5,6.5 6,10.5 9.5,6.5" />
+            </svg>
+          </span>
+          <span class="cv-dl-line" aria-hidden="true"></span>
+        </a>
+      ))}
+
       <div class="id-links">
         <a href={`mailto:${links.email}`}>Email ↗</a>
         <a href={links.github} target="_blank" rel="noopener">GitHub ↗</a>

--- a/site/src/components/deck/screens/Home.astro
+++ b/site/src/components/deck/screens/Home.astro
@@ -1,5 +1,5 @@
 ---
-import { SCREENS, home, links } from '../../../data/deck';
+import { SCREENS, chrome, home, links } from '../../../data/deck';
 import T from '../T.astro';
 
 const s = SCREENS[0];
@@ -46,7 +46,10 @@ const s = SCREENS[0];
       ))}
 
       <div class="id-links">
-        <a href={`mailto:${links.email}`}>Email ↗</a>
+        <span class="copy-wrap">
+          <a href={`mailto:${links.email}`} data-copy={links.email}>Email ↗</a>
+          <span class="copy-live" role="status"><T t={chrome.copied} class="copy-flag" /></span>
+        </span>
         <a href={links.github} target="_blank" rel="noopener">GitHub ↗</a>
         <a href={links.linkedin} target="_blank" rel="noopener">LinkedIn ↗</a>
       </div>

--- a/site/src/components/deck/screens/OpenSource.astro
+++ b/site/src/components/deck/screens/OpenSource.astro
@@ -3,7 +3,8 @@ import { SCREENS, openSource } from '../../../data/deck';
 import SecHead from '../SecHead.astro';
 import T from '../T.astro';
 
-const s = SCREENS[4];
+const i = 3;
+const s = SCREENS[i];
 ---
 <section
   class="screen screen--os"
@@ -12,7 +13,7 @@ const s = SCREENS[4];
   data-en={s.label.en}
   hidden
 >
-  <SecHead label={s.label} heading={s.heading} index={4} />
+  <SecHead label={s.label} heading={s.heading} index={i} />
 
   {openSource.map((row) => {
     const Tag = row.href ? 'a' : 'div';

--- a/site/src/components/deck/screens/Research.astro
+++ b/site/src/components/deck/screens/Research.astro
@@ -3,7 +3,8 @@ import { SCREENS, research } from '../../../data/deck';
 import SecHead from '../SecHead.astro';
 import T from '../T.astro';
 
-const s = SCREENS[3];
+const i = 2;
+const s = SCREENS[i];
 const { program, publication } = research;
 ---
 <section
@@ -13,7 +14,7 @@ const { program, publication } = research;
   data-en={s.label.en}
   hidden
 >
-  <SecHead label={s.label} index={3} />
+  <SecHead label={s.label} index={i} />
 
   <div class="lead">
     <T t={program.eyebrow} as="div" class="eyebrow eyebrow--live" />

--- a/site/src/components/deck/screens/Systems.astro
+++ b/site/src/components/deck/screens/Systems.astro
@@ -3,7 +3,8 @@ import { SCREENS, systems } from '../../../data/deck';
 import SecHead from '../SecHead.astro';
 import T from '../T.astro';
 
-const s = SCREENS[2];
+const i = 1;
+const s = SCREENS[i];
 const { lead, prototype } = systems;
 ---
 <section
@@ -13,7 +14,7 @@ const { lead, prototype } = systems;
   data-en={s.label.en}
   hidden
 >
-  <SecHead label={s.label} index={2} />
+  <SecHead label={s.label} index={i} />
 
   <div class="lead">
     <T t={lead.eyebrow} as="div" class="eyebrow eyebrow--live" />

--- a/site/src/data/deck.ts
+++ b/site/src/data/deck.ts
@@ -29,21 +29,52 @@ export interface Screen {
    * more words gets its own string rather than widening the nav.
    */
   heading?: Bi;
+  /**
+   * How the particle field is composed behind this screen. These belong to the
+   * section, not to its position: the copy on each screen was written against a
+   * particular formation, brightness and cloud placement, so reordering the
+   * narrative must not reshuffle the visuals underneath it.
+   *
+   * `shape` indexes the formation table in scripts/field.ts (0 sphere shell ·
+   * 1 spiral galaxy · 2 two lobes · 3 torus · 4 double helix · 5 lattice cube ·
+   * 6 ring with core). `offset` slides the cloud right so copy sits on unlit
+   * background; `dim` is the alpha multiplier for text-dense screens.
+   */
+  field: { shape: number; offset: number; dim: number };
 }
 
-/** Screen order drives the nav, the SYS.NN readout and the particle shape index. */
+/** Text-dense screens: cloud pushed aside, field pulled back behind the copy. */
+const DENSE = { offset: 1.42, dim: 0.42 };
+
+/**
+ * Screen order drives the nav and the SYS.NN readout — the ordinals follow
+ * position. Visual direction travels with the section via `field`.
+ *
+ * The narrative runs promise → applied evidence → scientific evidence →
+ * external validation → track record → philosophy → contact: Approach sits
+ * late so it reads as a synthesis earned by the evidence before it, rather
+ * than as a claim staked ahead of it.
+ */
 export const SCREENS: Screen[] = [
-  { num: '00', label: { es: 'Home', en: 'Home' } },
-  { num: '01', label: { es: 'Enfoque', en: 'Approach' } },
-  { num: '02', label: { es: 'Sistemas', en: 'Systems' } },
-  { num: '03', label: { es: 'Investigación', en: 'Research' } },
+  { num: '00', label: { es: 'Home', en: 'Home' }, field: { shape: 0, offset: 0, dim: 1 } },
+  { num: '01', label: { es: 'Sistemas', en: 'Systems' }, field: { shape: 5, ...DENSE } },
+  { num: '02', label: { es: 'Investigación', en: 'Research' }, field: { shape: 4, ...DENSE } },
   {
-    num: '04',
+    num: '03',
     label: { es: 'Open Source', en: 'Open Source' },
     heading: { es: 'Contribuciones Open Source', en: 'Contributions Open Source' },
+    field: { shape: 1, ...DENSE },
   },
-  { num: '05', label: { es: 'Trayectoria', en: 'Career' } },
-  { num: '06', label: { es: 'Contacto', en: 'Contact' } },
+  { num: '04', label: { es: 'Trayectoria', en: 'Career' }, field: { shape: 3, ...DENSE } },
+  {
+    num: '05',
+    label: { es: 'Enfoque', en: 'Approach' },
+    // Two lobes — one thing gained, one thing given up — because that is what
+    // the copy on this screen names. The sheet is the one inverted screen, so
+    // it keeps the bright, near-centred cloud it was composed against.
+    field: { shape: 2, offset: 0.08, dim: 1 },
+  },
+  { num: '06', label: { es: 'Contacto', en: 'Contact' }, field: { shape: 6, ...DENSE } },
 ];
 
 /** Nav shows the first six; Contact is the outlined CTA. */
@@ -108,44 +139,22 @@ export const home = {
   name: 'Rody Vilchez',
   role: 'Applied ML Engineer',
   org: 'AI Intern · CIP–CGIAR',
-};
-
-/* ------------------------------------------------------------ 01 approach */
-
-export const approach = {
-  lede: {
-    es: 'Todo modelo optimiza algo y sacrifica otra cosa. Mi trabajo es <span class="hl">hacer explícito ese intercambio.</span>',
-    en: 'Every model optimizes something and sacrifices something else. My job is <span class="hl">making that trade explicit.</span>',
-  },
-  notes: [
-    {
-      num: '[ 01 ]',
-      title: { es: 'Validar el objetivo', en: 'Validate the target' },
-      body: {
-        es: 'Entender qué representa realmente la variable observada.',
-        en: 'Understand what the observed variable actually represents.',
-      },
-    },
-    {
-      num: '[ 02 ]',
-      title: { es: 'Evaluar consecuencias', en: 'Evaluate consequences' },
-      body: {
-        es: 'Estudiar cómo falla el modelo y qué decisiones dependen de sus resultados.',
-        en: 'Study how the model fails and which decisions depend on its outputs.',
-      },
-    },
-    {
-      num: '[ 03 ]',
-      title: { es: 'Dejar evidencia', en: 'Leave evidence' },
-      body: {
-        es: 'Hacer reproducibles los experimentos y trazables las decisiones técnicas.',
-        en: 'Make experiments reproducible and technical decisions traceable.',
-      },
-    },
+  /**
+   * The hero's one CTA. Both editions are rendered and CSS picks by `data-lang`,
+   * the same way `T` works — the language toggle writes one attribute and does
+   * not re-render, so the href cannot be branched at build time.
+   *
+   * `file` becomes the `download` attribute: the label says DESCARGAR/DOWNLOAD
+   * and the arrow points down, so this downloads rather than opening a tab.
+   * Paths keep the exact casing of `public/` — Netlify serves case-sensitively.
+   */
+  cv: [
+    { lang: 'es', href: links.cvEs, file: 'Rody-Vilchez-CV-es.pdf', label: 'Descargar CV' },
+    { lang: 'en', href: links.cvEn, file: 'Rody-Vilchez-CV-en.pdf', label: 'Download CV' },
   ],
 };
 
-/* ------------------------------------------------------------- 02 systems */
+/* ------------------------------------------------------------- 01 systems */
 
 export const systems = {
   lead: {
@@ -186,7 +195,7 @@ export const systems = {
   },
 };
 
-/* ------------------------------------------------------------ 03 research */
+/* ------------------------------------------------------------ 02 research */
 
 export const research = {
   program: {
@@ -237,7 +246,7 @@ export const research = {
   },
 };
 
-/* --------------------------------------------------------- 04 open source */
+/* --------------------------------------------------------- 03 open source */
 
 export interface OpenSourceRow {
   mark: string;
@@ -305,7 +314,7 @@ export const openSource: OpenSourceRow[] = [
   },
 ];
 
-/* -------------------------------------------------------------- 05 career */
+/* -------------------------------------------------------------- 04 career */
 
 export interface CareerRow {
   when: Bi;
@@ -351,6 +360,41 @@ export const career: CareerRow[] = [
     },
   },
 ];
+
+/* ------------------------------------------------------------ 05 approach */
+
+export const approach = {
+  lede: {
+    es: 'Todo modelo optimiza algo y sacrifica otra cosa. Mi trabajo es <span class="hl">hacer explícito ese intercambio.</span>',
+    en: 'Every model optimizes something and sacrifices something else. My job is <span class="hl">making that trade explicit.</span>',
+  },
+  notes: [
+    {
+      num: '[ 01 ]',
+      title: { es: 'Validar el objetivo', en: 'Validate the target' },
+      body: {
+        es: 'Entender qué representa realmente la variable observada.',
+        en: 'Understand what the observed variable actually represents.',
+      },
+    },
+    {
+      num: '[ 02 ]',
+      title: { es: 'Evaluar consecuencias', en: 'Evaluate consequences' },
+      body: {
+        es: 'Estudiar cómo falla el modelo y qué decisiones dependen de sus resultados.',
+        en: 'Study how the model fails and which decisions depend on its outputs.',
+      },
+    },
+    {
+      num: '[ 03 ]',
+      title: { es: 'Dejar evidencia', en: 'Leave evidence' },
+      body: {
+        es: 'Hacer reproducibles los experimentos y trazables las decisiones técnicas.',
+        en: 'Make experiments reproducible and technical decisions traceable.',
+      },
+    },
+  ],
+};
 
 /* ------------------------------------------------------------- 06 contact */
 

--- a/site/src/data/deck.ts
+++ b/site/src/data/deck.ts
@@ -98,6 +98,7 @@ export const chrome = {
   contact: { es: 'Contacto', en: 'Contact' },
   status: { es: 'Disponible', en: 'Open to roles' },
   more: { es: 'Sigue', en: 'More' },
+  copied: { es: 'Dirección copiada', en: 'Address copied' },
   stats: {
     particles: { es: 'Partículas vivas', en: 'Live particles' },
     /**

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -4,11 +4,11 @@ import Boot from '../components/deck/Boot.astro';
 import TopBar from '../components/deck/TopBar.astro';
 import StatsBar from '../components/deck/StatsBar.astro';
 import Home from '../components/deck/screens/Home.astro';
-import Approach from '../components/deck/screens/Approach.astro';
 import Systems from '../components/deck/screens/Systems.astro';
 import Research from '../components/deck/screens/Research.astro';
 import OpenSource from '../components/deck/screens/OpenSource.astro';
 import Career from '../components/deck/screens/Career.astro';
+import Approach from '../components/deck/screens/Approach.astro';
 import Contact from '../components/deck/screens/Contact.astro';
 import { chrome } from '../data/deck';
 import T from '../components/deck/T.astro';
@@ -84,11 +84,11 @@ const profilePageJsonLd = {
     <main class="panes">
       <div class="pane" id="pane">
         <Home />
-        <Approach />
         <Systems />
         <Research />
         <OpenSource />
         <Career />
+        <Approach />
         <Contact />
       </div>
     </main>

--- a/site/src/scripts/deck.ts
+++ b/site/src/scripts/deck.ts
@@ -211,6 +211,32 @@ export function initDeck() {
     if (pane) pane.scrollBy({ top: Math.round(pane.clientHeight * 0.8), behavior: 'smooth' });
   });
 
+  /**
+   * Email links copy the address alongside the navigation — the `mailto:` is
+   * deliberately left to fire, so a visitor with a mail client still gets it.
+   * The copy is for the case where the scheme has no registered handler and
+   * the click dies silently, which is most of the ways this can go wrong.
+   *
+   * `navigator.clipboard` needs a secure context; on plain http the click
+   * degrades to today's behaviour rather than showing a flag that lied.
+   */
+  document.querySelectorAll<HTMLAnchorElement>('a[data-copy]').forEach((a) => {
+    const wrap = a.closest('.copy-wrap');
+    let flagTimer = 0;
+    a.addEventListener('click', () => {
+      const value = a.dataset.copy;
+      if (!value || !wrap || !navigator.clipboard) return;
+      navigator.clipboard
+        .writeText(value)
+        .then(() => {
+          wrap.classList.add('is-copied');
+          window.clearTimeout(flagTimer);
+          flagTimer = window.setTimeout(() => wrap.classList.remove('is-copied'), 1800);
+        })
+        .catch(() => {});
+    });
+  });
+
   document.addEventListener('keydown', (e) => {
     if (e.metaKey || e.ctrlKey || e.altKey) return;
     const tag = (e.target as HTMLElement | null)?.tagName;

--- a/site/src/scripts/field.ts
+++ b/site/src/scripts/field.ts
@@ -11,6 +11,8 @@
  * ported unchanged.
  */
 
+import { SCREENS } from '../data/deck';
+
 export interface FieldOptions {
   /** Number of points. */
   count: number;
@@ -33,15 +35,12 @@ const GA = 2.399963;
 const MORPH_MS = 1500;
 
 /**
- * Screen → formation. Deliberately not the identity mapping: screen 01
- * (Approach) gets the two lobes, which read as the trade the copy names, and
- * the denser screens get the quieter shapes.
+ * How each screen composes the field — formation, cloud placement and
+ * brightness. This is authored per section in data/deck.ts, not derived from
+ * the screen's position, so reordering the narrative moves each screen's
+ * visual treatment along with it. See `Screen.field` there.
  */
-const SHAPES = [0, 2, 5, 4, 1, 3, 6];
-
-/** Screens from 02 on are text-dense, so the field pulls back behind them. */
-const DENSE_FROM = 2;
-const DENSE_ALPHA = 0.42;
+const COMPOSITION = SCREENS.map((s) => s.field);
 
 /** Deterministic per-point hash; same sequence every load. */
 function rnd(i: number, s: number): number {
@@ -410,13 +409,11 @@ export function createField(host: HTMLElement, opts: FieldOptions): Field | null
     const raw = reduced ? 1 : Math.min(1, (now - morphStart) / MORPH_MS);
     mixNow = raw * raw * (3 - 2 * raw);
 
-    // Home centres the cloud; Approach nudges it; from Systems on it slides
-    // right so the copy sits on unlit background.
-    const target = screen === 0 ? 0 : screen === 1 ? 0.08 : 1.42;
-    px += (target - px) * (reduced ? 1 : 0.05);
-
-    const dimTarget = screen >= DENSE_FROM ? DENSE_ALPHA : 1;
-    dim += (dimTarget - dim) * (reduced ? 1 : 0.06);
+    // Home centres the cloud; Approach nudges it; the text-dense screens slide
+    // it right so the copy sits on unlit background.
+    const comp = COMPOSITION[screen];
+    px += (comp.offset - px) * (reduced ? 1 : 0.05);
+    dim += (comp.dim - dim) * (reduced ? 1 : 0.06);
 
     modelView(mv, my * 0.3, tsec * 0.075 + mx * 0.5, px + mx * 0.12, 3.5);
 
@@ -448,8 +445,8 @@ export function createField(host: HTMLElement, opts: FieldOptions): Field | null
   return {
     count: N,
     setShape(index: number) {
-      screen = Math.max(0, Math.min(SHAPES.length - 1, index));
-      const next = SHAPES[screen];
+      screen = Math.max(0, Math.min(COMPOSITION.length - 1, index));
+      const next = COMPOSITION[screen].shape;
       if (next === shape) return;
       retarget(next);
     },

--- a/site/src/styles/vesper.css
+++ b/site/src/styles/vesper.css
@@ -35,6 +35,12 @@
   --v-line-22: rgba(237, 239, 238, 0.22);
   --v-line-24: rgba(237, 239, 238, 0.24);
 
+  /* Accent at rest and on approach. The CV CTA sits lit rather than neutral,
+     so its line needs a range to travel: dim green is the resting state and
+     the sweep arrives at full --v-green. */
+  --v-green-32: rgba(59, 224, 166, 0.32);
+  --v-green-58: rgba(59, 224, 166, 0.58);
+
   /* Inter Variable stands in for the source's Helvetica Neue: the deck leans on
      weight 200 throughout, which Helvetica Neue does not ship on most systems.
      Inter is self-hosted and has a true 200. */
@@ -155,15 +161,14 @@ a:hover {
   }
 }
 
+/* The terminal is already green, so the pulse is size, not colour. */
 @keyframes v3-cv-terminal {
   0%,
   100% {
     transform: scale(1);
-    background: var(--v-dim-4);
   }
   40% {
-    transform: scale(1.9);
-    background: var(--v-green);
+    transform: scale(2.1);
   }
 }
 
@@ -673,18 +678,21 @@ a:hover {
    beside the chips — that block is conceptual, and a button there turns it into
    a toolbar.
 
-   Everything the CTA says is said statically; hover only confirms it. The whole
-   effect is CSS on two pseudo-elements, so it adds no work to the WebGL field
-   drawing behind it. */
+   It rests lit: green label, green line, a terminal at each end. Everything the
+   CTA says is said statically and hover only confirms it. The whole effect is
+   CSS on two pseudo-elements and a background layer, so it adds no work to the
+   WebGL field drawing behind it. */
 .cv-dl {
   display: inline-flex;
   flex-direction: column;
-  gap: 0.4375rem;
+  /* Tuned against the 7px line box: 2px of it sits above the hairline. */
+  gap: 0.3125rem;
   /* The drawing is ~1.25rem tall; the rest buys the touch target. 2.75rem at
      the deck's 125% root is 55px, comfortably over the 44px floor. */
   min-height: 2.75rem;
   justify-content: center;
   margin-top: 0.9375rem;
+  color: var(--v-green);
   font-size: 0.6875rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -696,22 +704,34 @@ a:hover {
   gap: 0.5rem;
 }
 
-/* 3px tall so the terminal dot survives the clip that keeps the sweeping
-   segment inside the line; the hairline itself is painted mid-height. */
+/* The box has to be tall enough for the right terminal at full pulse (3px dot
+   at 2.1x = 6.3px), because `overflow: hidden` — which keeps the sweeping
+   segment inside the line — would otherwise clip the growing dot into a
+   rectangle. The hairline is painted mid-height, and `.cv-dl`'s gap is tuned
+   against this height so the optical spacing matches the row above.
+
+   Two background layers: the line, and the left terminal that marks where the
+   sweep starts. The right terminal is ::after, because it has to pulse. */
 .cv-dl-line {
   position: relative;
   overflow: hidden;
-  height: 3px;
-  background: linear-gradient(var(--v-line-16), var(--v-line-16)) 0 50% / 100% 1px no-repeat;
+  height: 7px;
+  background:
+    radial-gradient(circle, var(--v-green) 0 1.5px, transparent 1.5px) 0 50% / 3px 3px no-repeat,
+    linear-gradient(var(--v-green-32), var(--v-green-32)) 0 50% / 100% 1px no-repeat;
 }
 
+/* The only state change reduced motion keeps: the line comes up to strength.
+   The label is already green, so contrast has to live here. */
 .cv-dl:hover .cv-dl-line,
 .cv-dl:focus-visible .cv-dl-line {
-  background-image: linear-gradient(var(--v-line-24), var(--v-line-24));
+  background-image:
+    radial-gradient(circle, var(--v-green) 0 1.5px, transparent 1.5px),
+    linear-gradient(var(--v-green-58), var(--v-green-58));
 }
 
 /* The travelling segment. Parked off the left edge, so nothing lingers once
-   the pointer leaves. */
+   the pointer leaves. Full --v-green against the dim line it crosses. */
 .cv-dl-line::before {
   content: '';
   position: absolute;
@@ -733,7 +753,10 @@ a:hover {
   height: 3px;
   margin-top: -1.5px;
   border-radius: 50%;
-  background: var(--v-dim-4);
+  background: var(--v-green);
+  /* Grows inward from the line's end. A centred origin would push half the
+     pulse past the right edge, where `overflow: hidden` flattens it. */
+  transform-origin: right center;
 }
 
 .cv-dl:hover .cv-dl-line::before,
@@ -752,9 +775,9 @@ a:hover {
   animation: v3-cv-arrow 260ms ease-in-out;
 }
 
-/* Reduced motion keeps the meaning — the link still lights up green through
-   the global `a:hover`, and the hairline still gains contrast — and drops
-   every moving part. */
+/* Reduced motion keeps the meaning — the line still comes up from dim green to
+   full strength, which is the whole acknowledgement — and drops every moving
+   part. */
 @media (prefers-reduced-motion: reduce) {
   .cv-dl:hover .cv-dl-line::before,
   .cv-dl:focus-visible .cv-dl-line::before,

--- a/site/src/styles/vesper.css
+++ b/site/src/styles/vesper.css
@@ -673,6 +673,46 @@ a:hover {
   font-size: 0.625rem;
 }
 
+/* Email links copy the address as well as handing it to the mail client.
+   A `mailto:` on a machine with no registered handler fails silently — the
+   visitor clicks the one contact affordance and nothing at all happens, with
+   no error and no hint. The flag is the only evidence the click did anything,
+   so it is the fallback path that has to be legible, not a flourish.
+
+   Used by both the hero link and the Contact address. */
+.copy-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.copy-flag {
+  position: absolute;
+  left: 0;
+  /* Below, not above: in the hero the space above the links belongs to the CV
+     CTA, and an opaque flag there would black out the thing it sits on. */
+  top: calc(100% + 0.5rem);
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--v-green-58);
+  background: #000;
+  color: var(--v-green);
+  font-family: var(--v-mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  opacity: 0;
+  transform: translateY(-0.25rem);
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
+  pointer-events: none;
+}
+
+.copy-wrap.is-copied .copy-flag {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 /* The hero's one CTA, between the identity lines and the social links: an
    action on the card rather than a fourth link. It is deliberately not placed
    beside the chips — that block is conceptual, and a button there turns it into
@@ -1455,7 +1495,10 @@ a:hover {
   .pub-cover,
   .pub-doi,
   .more,
-  .lang-btn {
+  .lang-btn,
+  /* The flag still appears — it is feedback, not decoration. Only the fade
+     and the rise are dropped. */
+  .copy-flag {
     transition: none;
   }
 }

--- a/site/src/styles/vesper.css
+++ b/site/src/styles/vesper.css
@@ -142,6 +142,41 @@ a:hover {
   }
 }
 
+/* CV download CTA. Three one-shot gestures, no loops: the segment crosses the
+   line, the terminal acknowledges it, the arrow dips. `264%` is the segment's
+   own width (38% of the line) travelled across the full line, which carries it
+   clear of the right edge. */
+@keyframes v3-cv-sweep {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(264%);
+  }
+}
+
+@keyframes v3-cv-terminal {
+  0%,
+  100% {
+    transform: scale(1);
+    background: var(--v-dim-4);
+  }
+  40% {
+    transform: scale(1.9);
+    background: var(--v-green);
+  }
+}
+
+@keyframes v3-cv-arrow {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  45% {
+    transform: translateY(2px);
+  }
+}
+
 /* ------------------------------------------------------------------- shell */
 
 .deck {
@@ -633,69 +668,105 @@ a:hover {
   font-size: 0.625rem;
 }
 
-/* ------------------------------------------------------------ 01 approach */
+/* The hero's one CTA, between the identity lines and the social links: an
+   action on the card rather than a fourth link. It is deliberately not placed
+   beside the chips — that block is conceptual, and a button there turns it into
+   a toolbar.
 
-.sheet {
-  background: var(--v-sheet);
-  color: var(--v-sheet-ink);
-  padding: clamp(1.875rem, 3.6vw, 3.375rem);
-  box-shadow: 0 3.125rem 7.5rem rgba(0, 0, 0, 0.75);
+   Everything the CTA says is said statically; hover only confirms it. The whole
+   effect is CSS on two pseudo-elements, so it adds no work to the WebGL field
+   drawing behind it. */
+.cv-dl {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.4375rem;
+  /* The drawing is ~1.25rem tall; the rest buys the touch target. 2.75rem at
+     the deck's 125% root is 55px, comfortably over the 44px floor. */
+  min-height: 2.75rem;
+  justify-content: center;
+  margin-top: 0.9375rem;
+  font-size: 0.6875rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
 
-/* The sheet inverts the deck, so its header drops the light hairline and
-   switches to the sheet's own dim tiers. */
-.sheet .sec-head {
-  color: var(--v-sheet-dim);
-  padding-bottom: 0;
-  border-bottom: none;
-  margin-bottom: 1.5rem;
+.cv-dl-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.sheet .sec-head b {
-  color: #b4bab7;
+/* 3px tall so the terminal dot survives the clip that keeps the sweeping
+   segment inside the line; the hairline itself is painted mid-height. */
+.cv-dl-line {
+  position: relative;
+  overflow: hidden;
+  height: 3px;
+  background: linear-gradient(var(--v-line-16), var(--v-line-16)) 0 50% / 100% 1px no-repeat;
 }
 
-.sheet-lede {
-  font-size: clamp(1.6875rem, 3.6vw, 3.25rem);
-  font-weight: 200;
-  line-height: 1.08;
-  letter-spacing: -0.035em;
-  margin: 0;
-  max-width: 24ch;
+.cv-dl:hover .cv-dl-line,
+.cv-dl:focus-visible .cv-dl-line {
+  background-image: linear-gradient(var(--v-line-24), var(--v-line-24));
 }
 
-.sheet-notes {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: clamp(1.375rem, 3.4vw, 3.5rem);
-  margin-top: clamp(1.625rem, 3.4vw, 2.875rem);
-  padding-top: 1.625rem;
-  border-top: 1px solid rgba(10, 12, 12, 0.14);
+/* The travelling segment. Parked off the left edge, so nothing lingers once
+   the pointer leaves. */
+.cv-dl-line::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 38%;
+  height: 1px;
+  margin-top: -0.5px;
+  background: var(--v-green);
+  transform: translateX(-100%);
 }
 
-.note-num {
-  font-family: var(--v-mono);
-  font-size: 0.625rem;
-  letter-spacing: 0.2em;
-  color: var(--v-sheet-dim);
-  margin-bottom: 0.75rem;
+.cv-dl-line::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  top: 50%;
+  width: 3px;
+  height: 3px;
+  margin-top: -1.5px;
+  border-radius: 50%;
+  background: var(--v-dim-4);
 }
 
-.note-title {
-  font-size: 1.0625rem;
-  font-weight: 400;
-  letter-spacing: -0.015em;
-  margin-bottom: 0.5rem;
+.cv-dl:hover .cv-dl-line::before,
+.cv-dl:focus-visible .cv-dl-line::before {
+  animation: v3-cv-sweep 260ms linear;
 }
 
-.note-body {
-  margin: 0;
-  font-size: 0.8125rem;
-  line-height: 1.65;
-  color: var(--v-sheet-body);
+/* Fires as the segment lands, once. */
+.cv-dl:hover .cv-dl-line::after,
+.cv-dl:focus-visible .cv-dl-line::after {
+  animation: v3-cv-terminal 300ms ease-out 260ms;
 }
 
-/* --------------------------------------------- 02 systems + 03 research */
+.cv-dl:hover .cv-dl-arrow,
+.cv-dl:focus-visible .cv-dl-arrow {
+  animation: v3-cv-arrow 260ms ease-in-out;
+}
+
+/* Reduced motion keeps the meaning — the link still lights up green through
+   the global `a:hover`, and the hairline still gains contrast — and drops
+   every moving part. */
+@media (prefers-reduced-motion: reduce) {
+  .cv-dl:hover .cv-dl-line::before,
+  .cv-dl:focus-visible .cv-dl-line::before,
+  .cv-dl:hover .cv-dl-line::after,
+  .cv-dl:focus-visible .cv-dl-line::after,
+  .cv-dl:hover .cv-dl-arrow,
+  .cv-dl:focus-visible .cv-dl-arrow {
+    animation: none;
+  }
+}
+
+/* --------------------------------------------- 01 systems + 02 research */
 
 /* Both screens open with one headline block and follow it with a paired
    row — a media frame on Systems, the proceedings cover on Research. */
@@ -867,7 +938,7 @@ a:hover {
   border-color: var(--v-green);
 }
 
-/* --------------------------------------------------------- 04 open source */
+/* --------------------------------------------------------- 03 open source */
 
 .os-row {
   display: grid;
@@ -937,7 +1008,7 @@ a:hover {
   max-width: 26ch;
 }
 
-/* -------------------------------------------------------------- 05 career */
+/* -------------------------------------------------------------- 04 career */
 
 .lin-row {
   display: grid;
@@ -986,6 +1057,68 @@ a:hover {
   font-size: 0.8125rem;
   line-height: 1.65;
   color: var(--v-dim-1);
+}
+
+/* ------------------------------------------------------------ 05 approach */
+
+.sheet {
+  background: var(--v-sheet);
+  color: var(--v-sheet-ink);
+  padding: clamp(1.875rem, 3.6vw, 3.375rem);
+  box-shadow: 0 3.125rem 7.5rem rgba(0, 0, 0, 0.75);
+}
+
+/* The sheet inverts the deck, so its header drops the light hairline and
+   switches to the sheet's own dim tiers. */
+.sheet .sec-head {
+  color: var(--v-sheet-dim);
+  padding-bottom: 0;
+  border-bottom: none;
+  margin-bottom: 1.5rem;
+}
+
+.sheet .sec-head b {
+  color: #b4bab7;
+}
+
+.sheet-lede {
+  font-size: clamp(1.6875rem, 3.6vw, 3.25rem);
+  font-weight: 200;
+  line-height: 1.08;
+  letter-spacing: -0.035em;
+  margin: 0;
+  max-width: 24ch;
+}
+
+.sheet-notes {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(1.375rem, 3.4vw, 3.5rem);
+  margin-top: clamp(1.625rem, 3.4vw, 2.875rem);
+  padding-top: 1.625rem;
+  border-top: 1px solid rgba(10, 12, 12, 0.14);
+}
+
+.note-num {
+  font-family: var(--v-mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.2em;
+  color: var(--v-sheet-dim);
+  margin-bottom: 0.75rem;
+}
+
+.note-title {
+  font-size: 1.0625rem;
+  font-weight: 400;
+  letter-spacing: -0.015em;
+  margin-bottom: 0.5rem;
+}
+
+.note-body {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.65;
+  color: var(--v-sheet-body);
 }
 
 /* ------------------------------------------------------------- 06 contact */


### PR DESCRIPTION
Three changes to the home deck, in the order they were decided.

## Approach moves to penultimate

The deck argued its philosophy before showing any evidence for it. The narrative now runs promise → applied evidence → scientific evidence → external validation → track record → philosophy → contact.

**Ordinals follow position; visual direction follows the section.** The screen → formation mapping, the cloud offset and the dim factor moved out of `field.ts` into `Screen.field`, because each screen's copy was composed against a particular formation and brightness. `SHAPES` was never the identity mapping — Approach keeps the two lobes it was given for naming a trade-off, and keeps the bright, near-centred cloud its inverted sheet was designed against.

## Hero CV CTA

One CTA between the identity lines and the social links — deliberately not beside the chips, which are conceptual and would become a toolbar. Both language editions ship in the HTML and CSS picks one, the same way `T` works, since the language toggle writes an attribute and does not re-render. It downloads rather than opening a tab, and the paths keep the exact casing of `public/` because Netlify serves case-sensitively.

It rests lit — green label, green line, a terminal at each end. The resting line is dim green so the sweep has somewhere to arrive; the travelling segment stays full `--v-green`. Hover and focus-visible run three one-shot gestures in CSS only, adding no work to the WebGL field. `prefers-reduced-motion` keeps the line's contrast change and drops every moving part.

## Email links copy the address

A `mailto:` with no registered scheme handler fails silently — the visitor clicks the one contact affordance and nothing happens, with no error and no hint. Both email links now copy the address alongside the navigation; the `mailto:` still fires, so anyone with a mail client gets what they expected.

## Verification

Driven headlessly against the production build:

| | Result |
|---|---|
| Order | `SYS.00…06`, ordinals `001…006`, Enfoque at `05 / 06` |
| CTA at rest | label `rgb(59,224,166)`, line at 32%, sweep parked off-canvas |
| Sweep | `-39.3px` → `+68.3px` across a 144px line |
| Terminal pulse | `scale 2.07` → `1.85`, round, unclipped |
| Copy | clipboard = `rody@rosewt.dev` on both screens, flag clears after 1.8s |
| Gates | `npm run build` and `npm run check`: 0 errors |

Known and deliberate: the CTA's touch target is 55px rather than 44 (`2.75rem` at the deck's 125% root), and the copy confirmation is visual — `role="status"` is set but the text is always in the DOM, so screen readers likely will not announce it.

Closes rv-66g.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PveEDoXL3pEF52gpJDyeeP

## Summary by Sourcery

Reorder the home deck narrative so the Approach section appears near the end, introduce a CV download call-to-action in the hero, and make email links copy the address as a fallback while keeping the particle field visuals aligned with their sections.

New Features:
- Add a hero CV download CTA that ships both language variants and uses CSS-only animations respecting reduced-motion preferences.
- Enable email links in the hero and Contact sections to copy the address to the clipboard alongside opening the mail client.
- Bind each deck screen to an explicit particle field composition so visual treatments travel with their sections when reordered.

Enhancements:
- Adjust screen numbering, headings, and layout so Systems, Research, Open Source, Career, and Approach reflect the new narrative order.
- Refine deck styling to support the CV CTA visuals and email copy feedback, including new green accent levels and copy status flags.

Chores:
- Configure bead sync to push to the GitHub remote for this project.