### PR TITLE
fix(site): drop llms.txt's dead link to llms-full.txt

### DIFF
--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -36,7 +36,6 @@ Applied Machine Learning Engineer, RAG Systems Engineer, Document AI Engineer, G
 - LinkedIn: [r0sewt](https://www.linkedin.com/in/r0sewt/)
 - CV (English): [CV.en.pdf](https://rosewt.dev/CV.en.pdf)
 - CV (Spanish): [CV.es.pdf](https://rosewt.dev/CV.es.pdf)
-- Full profile for LLMs: [llms-full.txt](https://rosewt.dev/llms-full.txt)
 
 ## Experience — CIP (CGIAR)
 


### PR DESCRIPTION
`llms.txt` closed its Links block with `Full profile for LLMs: rosewt.dev/llms-full.txt`. That file has never existed — verified 404 in production. It is a broken link in the one file whose entire job is to be read by a machine.

**Removing the line rather than writing the file.** Two reasons:

1. `llms.txt` here is not a short index needing an expanded companion — it already inlines the whole profile (experience, systems, skills, education, certifications). `llms-full.txt` would have duplicated it.
2. `llms.txt` is itself behind the v11 CV bundle, so a "full" version derived from it would have propagated stale claims instead of fixing them.

Nothing else in the repo referenced that URL — the line was the only thing keeping the promise alive. The other six links in the block were checked and all return 200.

Refreshing `llms.txt` against the CV bundle is tracked separately as rv-xq7.

Closes rv-4fu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PveEDoXL3pEF52gpJDyeeP

## Summary by Sourcery

Bug Fixes:
- Remove the broken llms-full.txt URL from llms.txt so the links block no longer points to a non-existent resource.