### PR TITLE
fix(evidence): back-propagate CV v11 into the claims registry

### DIFF
--- a/evidence/claims.md
+++ b/evidence/claims.md
@@ -26,7 +26,7 @@ Support references use one of these prefixes:
 ### exp-cip-001
 - `surface`: `both`
 - `publicable`: `yes`
-- `claim`: AI / Data Intern at International Potato Center (CIP, CGIAR), Lima, Peru, Oct 2025 to present.
+- `claim`: AI Intern at International Potato Center (CIP, CGIAR), Lima, Peru, Oct 2025 to present.
 - `supports`:
   - `vault_doc`: `cip_employment_2025_10`
   - `vault_doc`: `cip_employment_2026_04`
@@ -44,31 +44,57 @@ Support references use one of these prefixes:
 
 ## Systems
 
-### sys-ask-papa-001
+### sys-cip-agents-001
 - `surface`: `both`
-- `publicable`: `no`
-- `claim`: Internal work on document intelligence, GraphRAG, and metadata enrichment within current work at CIP; keep as internal context, not as a public claim to verify externally.
+- `publicable`: `yes`
+- `claim`: Architected and shipped an institutional multi-agent platform on Copilot Studio in Microsoft Teams at CIP, for IT support and corporate services, with cross-domain delegation and escalation to tickets prefilled from conversational context and subject to human review.
 - `supports`:
-  - `public_url`: `https://rosewt.dev/`
+  - `vault_doc`: `cip_employment_2026_04`
+
+### sys-cip-eval-001
+- `surface`: `both`
+- `publicable`: `yes`
+- `claim`: Built an agent-based evaluation suite at CIP in which evaluator agents execute scenarios derived from operational records, combining deterministic regression, provider-agnostic LLM-as-judge scoring, and persona-driven simulation to attribute routing, delegation, and response-quality failures.
+- `supports`:
+  - `vault_doc`: `cip_employment_2026_04`
+
+### sys-cip-graphrag-001
+- `surface`: `both`
+- `publicable`: `yes`
+- `claim`: Built end-to-end the document-intelligence layer powering a five-language agricultural GraphRAG at CIP over corpora with noisy OCR and irregular layouts, covering parsing, chunking, structured metadata extraction, embeddings, and vector storage.
+- `supports`:
+  - `vault_doc`: `cip_employment_2026_04`
+
+### sys-visma-testgen-001
+- `surface`: `both`
+- `publicable`: `yes`
+- `claim`: Built an LLM-driven agent at Visma LATAM that transforms functional specifications into executable end-to-end test scenarios.
+- `supports`:
+  - `vault_doc`: `visma_employment_2025_09`
+
+### sys-visma-dom-001
+- `surface`: `both`
+- `publicable`: `yes`
+- `claim`: Engineered DOM-aware selector and state extraction at Visma LATAM, integrating generated Cypress suites into Jenkins as regression coverage for critical workflows.
+- `supports`:
+  - `vault_doc`: `visma_employment_2025_09`
 
 ### sys-arbitria-001
-- `surface`: `both`
+- `surface`: `web`
 - `publicable`: `yes`
 - `claim`: Built a legal retrieval system for Peruvian arbitration documents with dual indexing and contextual QA.
 - `supports`:
   - `repo`: `https://github.com/ArbitrIA`
-  - `public_url`: `https://rosewt.dev/`
 
 ### sys-geno-map-001
-- `surface`: `both`
+- `surface`: `web`
 - `publicable`: `yes`
-- `claim`: Built a correspondence-free validation framework (GENO-MAP) for high-dimensional data analysis using kNN graph invariants; presented as a poster at SALA 2026.
+- `claim`: Built a correspondence-free validation framework (GENO-MAP) for high-dimensional data analysis using kNN graph invariants.
 - `supports`:
   - `repo`: `https://github.com/R0SEWT/GENO-MAP_Correspondence-Free-Diagnostics-for-Sweet-Potato-Diversity-Maps`
-  - `vault_doc`: `sala_2026_participation`
 
 ### sys-gallstone-001
-- `surface`: `both`
+- `surface`: `web`
 - `publicable`: `yes`
 - `claim`: Built a gallstone risk prediction system (Gallstone Risk) for resource-constrained screening, with a human-in-the-loop SHAP inspection interface.
 - `supports`:
@@ -76,45 +102,104 @@ Support references use one of these prefixes:
   - `public_url`: `https://gallstone.rosewt.dev/`
 
 ### sys-nao-001
-- `surface`: `both`
+- `surface`: `web`
 - `publicable`: `yes`
 - `claim`: Built a vision and robotics system for NAO emotion detection with optimized inference and end-to-end response handling.
 - `supports`:
   - `repo`: `https://github.com/R0SEWT/Nao-CNN-Emotion`
-  - `public_url`: `https://rosewt.dev/`
 
 ### sys-housing-001
-- `surface`: `both`
+- `surface`: `web`
 - `publicable`: `yes`
 - `claim`: Built a large-scale data pipeline and predictive modeling workflow over 1.5M Danish housing transactions.
 - `supports`:
   - `repo`: `https://github.com/R0SEWT/Denmark-HousePrices-Analysis`
-  - `public_url`: `https://rosewt.dev/`
 
 ### sys-potato-achis-001
-- `surface`: `both`
+- `surface`: `web`
 - `publicable`: `yes`
 - `claim`: Built potato-achis, a multi-source domain feature adaptation network (MDFAN) for Andean potato disease classification, with Andean field augmentations, open-set OOD rejection, and timm backbones (MobileNetV3/ResNet50), on a modern Python stack (uv, ruff, mypy, pytest, Hydra).
 - `supports`:
   - `repo`: `https://github.com/R0SEWT/potato-achis`
 
 ### sys-lumi-001
-- `surface`: `both`
+- `surface`: `web`
 - `publicable`: `yes`
 - `claim`: Built Lumi, a caregiver copilot that wraps LLM-generated proposals in deterministic medical-safety boundaries — a FastAPI service with Azure OpenAI, ports/adapters (hexagonal) architecture, and CI with tests, packaged for Docker-based deployment to Azure App Service.
 - `supports`:
   - `repo`: `https://github.com/R0SEWT/dermatomicos-Bago`
 
+### sys-wachi-001
+- `surface`: `both`
+- `publicable`: `yes`
+- `claim`: Built a geospatial system (Wachi) that re-ranks pedestrian routes by spatiotemporal risk in Lima using H3 surfaces, temporal decay, and six time bands, for an interactive data-journalism experience with El Comercio Lab.
+- `supports`:
+  - _No support reference yet._ The working repository is private and the public
+    `R0SEWT/inwach` holds only a LICENSE. This claim is already published on the CV
+    and the deck without traceable backing — see `rv-nbt`.
+
 ## Research
+
+### res-infelix-001
+- `surface`: `both`
+- `publicable`: `yes`
+- `claim`: Built a Bayesian model over victimization surveys and an 11-source H3 geospatial panel (Sentinel-2, VIIRS, OSM, WorldPop, Street View) to estimate crime risk across 43 Lima–Callao districts, as B.Sc. thesis research at UPC (2025–2026); census data were the only source that consistently improved predictions within districts.
+- `supports`:
+  - `public_url`: `https://r0sewt.github.io/infelix/`
+
+### res-infelix-002
+- `surface`: `both`
+- `publicable`: `yes`
+- `claim`: In Infelix, features learned in Lima matched models trained with one year of local data in Arequipa and remained competitive in Cusco and Piura; stress tests showed that record quality, not architecture alone, determines when the system can be evaluated and transferred.
+- `supports`:
+  - `public_url`: `https://r0sewt.github.io/infelix/`
 
 ### res-imitator-001
 - `surface`: `both`
 - `publicable`: `yes`
-- `claim`: Co-authored the multimodal sign language translation system "Imitator", presented at WAILAMP 2025 and SIMBIG 2025, accepted for Springer CCIS 2026 and pending publication.
+- `claim`: Co-authored the multimodal sign language translation system "Imitator", presented at WAILAMP 2025 and SIMBIG 2025 and published in Springer CCIS 2895 (2026), DOI 10.1007/978-3-032-20322-9_23.
 - `supports`:
+  - `paper`: `https://doi.org/10.1007/978-3-032-20322-9_23`
   - `repo`: `https://github.com/nakato156/Multimodal-Sign-Language-Model`
   - `vault_doc`: `imitator_simbig_authorship_2025_10`
   - `vault_doc`: `imitator_springer_publication_record`
+
+## Open Source
+
+Claim text here follows what the linked artifact actually shows, including merge
+state. The CV bundle, `site/src/data/deck.ts` and `site/public/llms.txt` all
+state the scikit-learn and Gemini CLI contributions more strongly than their
+evidence supports; the registry is the arbiter until they are brought in
+line — see `rv-486`.
+
+### oss-copilot-studio-001
+- `surface`: `both`
+- `publicable`: `yes`
+- `claim`: Reported and diagnosed a knowledge-source synchronization failure for child agents in Microsoft's official Copilot Studio VS Code extension, and validated the prerelease fix; issue closed Jul 6, 2026.
+- `supports`:
+  - `public_url`: `https://github.com/microsoft/vscode-copilotstudio/issues/324`
+
+### oss-beads-001
+- `surface`: `both`
+- `publicable`: `yes`
+- `claim`: Authored the prefix-routed write-through fix for `bd mol bond` in beads, together with the `TestMolBondPrefixRoutedWriteThrough` regression test that the maintainer identified as what distinguished this contribution from earlier attempts; the commit was carried into the upstream consolidation branch under contributor-first attribution. Pull request open with maintainer commits as of Aug 2026.
+- `supports`:
+  - `public_url`: `https://github.com/gastownhall/beads/pull/4720`
+  - `public_url`: `https://github.com/gastownhall/beads/issues/4714`
+
+### oss-gemini-cli-001
+- `surface`: `both`
+- `publicable`: `yes`
+- `claim`: Opened a pull request against Google's Gemini CLI adding missing `CustomTheme` properties to the settings validation schema, with regression coverage across eight files. Open and awaiting review since May 11, 2026 — not merged.
+- `supports`:
+  - `public_url`: `https://github.com/google-gemini/gemini-cli/pull/26844`
+
+### oss-hdbscan-001
+- `surface`: `both`
+- `publicable`: `yes`
+- `claim`: Merged a documentation fix in `scikit-learn-contrib/hdbscan` restoring a broken DOI link in the README. This is the scikit-learn-contrib ecosystem, not scikit-learn core, and the change is a link fix rather than a technical-documentation rewrite.
+- `supports`:
+  - `public_url`: `https://github.com/scikit-learn-contrib/hdbscan/pull/692`
 
 ## Education
 


### PR DESCRIPTION
The claims registry had drifted from CV v11. Eight assertions published on the CV, the deck and `llms.txt` had no entry at all, while `sys-ask-papa-001` marked the CIP work `publicable: no` even though the CV already publishes it. This back-propagates the CV and the site into `evidence/claims.md`.

**Scope: `evidence/claims.md` only.** Neither `cv/` nor `site/` is touched — the CV keeps its current wording, and the registry records where the evidence diverges from it.

## Registry: 22 → 35 claims

| Added | Why |
|---|---|
| `sys-cip-agents-001`, `sys-cip-eval-001`, `sys-cip-graphrag-001` | Replace `sys-ask-papa-001`, which forbade publishing work the CV already publishes |
| `sys-visma-testgen-001`, `sys-visma-dom-001` | `exp-visma-001` only covered the job title, not the two system bullets |
| `res-infelix-001`, `res-infelix-002` | The most quantitative claims on the CV (43 districts, 11 sources, 3 cities) had zero traceability. Split per the standard's rule against bundled claims |
| `sys-wachi-001` | Published on CV + deck + llms.txt with no entry |
| `oss-copilot-studio-001`, `oss-beads-001`, `oss-gemini-cli-001`, `oss-hdbscan-001` | The most verifiable claims in the deck were the least documented |

Updated: `res-imitator-001` from *"accepted, pending publication"* to published in Springer CCIS 2895 — the DOI becomes a public `paper` support, so two private `vault_doc`s are no longer the only backing. `exp-cip-001` to "AI Intern", matching the CV, deck and llms.txt.

Hygiene: six circular `public_url: https://rosewt.dev/` supports removed — the site is the surface being verified, not evidence for itself. Seven claims no longer carried by the CV moved from `surface: both` to `web`.

## Two published lines did not survive verification

The registry states what the artifacts show. Reconciling the CV and the site is deliberately left out of this PR — tracked in `rv-486` and `rv-kaa`.

- **scikit-learn** — the CV says *"Improved HDBSCAN technical documentation."* The contribution is [`scikit-learn-contrib/hdbscan#692`](https://github.com/scikit-learn-contrib/hdbscan/pull/692) (merged), *"Fix resolve broken DOI link in README"*. Not scikit-learn core, and a link fix rather than a documentation rewrite.
- **Gemini CLI** — the CV says *"Corrected a UI schema and added regression coverage."* [`gemini-cli#26844`](https://github.com/google-gemini/gemini-cli/pull/26844) has been open in `REVIEW_REQUIRED` since 2026-05-11.

For contrast, **beads** held up: the maintainer names `TestMolBondPrefixRoutedWriteThrough` as *"the difference between this PR and every earlier attempt"*, so that claim came out of verification stronger than it went in.

## One claim ships with no support, on purpose

`sys-wachi-001` has no support reference. The working repo (`R0SEWT/InWatch`) is private and the public `R0SEWT/inwach` holds only a LICENSE, so Wachi is published on the CV, the deck (with video) and `llms.txt` with nothing behind it. Fabricating a support is the exact failure this registry exists to catch, so the gap is written into the file. Tracked in `rv-nbt`.

## Verification

- All 35 blocks validated against the contract in `docs/standards/claims-registry.md`: required fields present, no duplicate IDs, every support prefix allowed, all 20 `vault_doc` references resolve to rows in `.cv-vault/INDEX.md`.
- Every support URL fetched: all 200 (LinkedIn returns its usual 999 anti-bot).

## Follow-ups

`rv-486` (CV wording for the two open-source lines), `rv-kaa` (site side: `deck.ts`, `llms.txt`, published PDFs), `rv-nbt` (Wachi evidence), `rv-a1y` (`profile.ts` still names the superseded procurement thesis — dead code, no page imports it), `rv-4os` (DataFest has three conflicting dates across the claim, the vault index row and the PDF filename).

Closes rv-g5b, rv-dnj, rv-8zi

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr5jYvvvn8eqp8rSUdn19f